### PR TITLE
Enables database-specific SNMP metrics

### DIFF
--- a/src/RavenBench/BenchmarkRunner.cs
+++ b/src/RavenBench/BenchmarkRunner.cs
@@ -515,8 +515,8 @@ public class BenchmarkRunner(RunOptions opts)
             ServerCpu = serverMetrics.CpuUsagePercent,
             ServerMemoryMB = serverMetrics.MemoryUsageMB,
             ServerRequestsPerSec = serverMetrics.RequestsPerSecond,
-            ServerIoReadOps = serverMetrics.IoReadOperations.HasValue ? (long)serverMetrics.IoReadOperations.Value : null,
-            ServerIoWriteOps = serverMetrics.IoWriteOperations.HasValue ? (long)serverMetrics.IoWriteOperations.Value : null,
+            ServerIoReadOps = serverMetrics.SnmpIoReadOpsPerSec.HasValue ? (long)serverMetrics.SnmpIoReadOpsPerSec.Value : null,
+            ServerIoWriteOps = serverMetrics.SnmpIoWriteOpsPerSec.HasValue ? (long)serverMetrics.SnmpIoWriteOpsPerSec.Value : null,
             ServerIoReadKb = serverMetrics.ReadThroughputKb,
             ServerIoWriteKb = serverMetrics.WriteThroughputKb,
 
@@ -622,7 +622,7 @@ public class BenchmarkRunner(RunOptions opts)
 
         try
         {
-            var snmpSample = await transport.GetSnmpMetricsAsync(opts.Snmp);
+            var snmpSample = await transport.GetSnmpMetricsAsync(opts.Snmp, opts.Database);
 
             if (!snmpSample.IsEmpty)
             {
@@ -635,6 +635,10 @@ public class BenchmarkRunner(RunOptions opts)
                     Console.WriteLine($"[Raven.Bench]   Managed Memory: {snmpSample.ManagedMemoryMb.Value} MB");
                 if (snmpSample.UnmanagedMemoryMb.HasValue)
                     Console.WriteLine($"[Raven.Bench]   Unmanaged Memory: {snmpSample.UnmanagedMemoryMb.Value} MB");
+                if (snmpSample.IoWriteOpsPerSec.HasValue)
+                    Console.WriteLine($"[Raven.Bench]   IO Write Ops/sec: {snmpSample.IoWriteOpsPerSec.Value}");
+                if (snmpSample.IoReadOpsPerSec.HasValue)
+                    Console.WriteLine($"[Raven.Bench]   IO Read Ops/sec: {snmpSample.IoReadOpsPerSec.Value}");
             }
             else
             {

--- a/src/RavenBench/Metrics/ServerMetrics.cs
+++ b/src/RavenBench/Metrics/ServerMetrics.cs
@@ -107,7 +107,7 @@ public sealed class ServerMetricsTracker : IDisposable
 
             if (_options.Snmp.Enabled)
             {
-                var snmpSample = await _transport.GetSnmpMetricsAsync(_options.Snmp);
+                var snmpSample = await _transport.GetSnmpMetricsAsync(_options.Snmp, _options.Database);
                 var snmpRates = _counterCache.ComputeRates(snmpSample);
 
                 // If we have rates (not the first sample), merge them into metrics

--- a/src/RavenBench/Metrics/Snmp/SnmpMetricMapper.cs
+++ b/src/RavenBench/Metrics/Snmp/SnmpMetricMapper.cs
@@ -8,9 +8,19 @@ public static class SnmpMetricMapper
 {
     /// <summary>
     /// Maps raw SNMP variables to a structured SnmpSample.
+    /// Automatically detects whether values contain server-wide or database-specific OIDs.
     /// </summary>
     public static SnmpSample MapToSample(Dictionary<string, Variable> values)
     {
+        // Try to extract IO/request metrics from any OID that matches the pattern
+        // This works for both server-wide and database-specific OIDs
+        var ioReadOps = ExtractByPattern(values, ".10.5") ?? ExtractByPattern(values, ".2.7");
+        var ioWriteOps = ExtractByPattern(values, ".10.6") ?? ExtractByPattern(values, ".2.8");
+        var ioReadBytes = ExtractByPattern(values, ".10.7") ?? ExtractByPattern(values, ".2.9");
+        var ioWriteBytes = ExtractByPattern(values, ".10.8") ?? ExtractByPattern(values, ".2.10");
+        var totalRequests = ExtractByPatternAsLong(values, ".7.2") ?? ExtractByPatternAsLong(values, ".3.6");
+        var requestsPerSec = ExtractByPattern(values, ".7.3") ?? ExtractByPattern(values, ".3.5");
+
         return new SnmpSample
         {
             Timestamp = DateTime.UtcNow,
@@ -22,13 +32,57 @@ public static class SnmpMetricMapper
             Load1Min = ExtractOctetStringAsDouble(values, SnmpOids.Load1Min),
             Load5Min = ExtractOctetStringAsDouble(values, SnmpOids.Load5Min),
             Load15Min = ExtractOctetStringAsDouble(values, SnmpOids.Load15Min),
-            IoReadOpsPerSec = ExtractGauge32AsDouble(values, SnmpOids.IoReadOps),
-            IoWriteOpsPerSec = ExtractGauge32AsDouble(values, SnmpOids.IoWriteOps),
-            IoReadKbPerSec = ExtractGauge32AsDouble(values, SnmpOids.IoReadBytes),
-            IoWriteKbPerSec = ExtractGauge32AsDouble(values, SnmpOids.IoWriteBytes),
-            TotalRequests = ExtractInteger32AsLong(values, SnmpOids.RequestCount),
-            RequestsPerSec = ExtractGauge32AsDouble(values, SnmpOids.RequestsPerSecond)
+            IoReadOpsPerSec = ioReadOps,
+            IoWriteOpsPerSec = ioWriteOps,
+            IoReadKbPerSec = ioReadBytes,
+            IoWriteKbPerSec = ioWriteBytes,
+            TotalRequests = totalRequests,
+            RequestsPerSec = requestsPerSec
         };
+    }
+
+    /// <summary>
+    /// Extracts a value from any OID ending with the given pattern.
+    /// </summary>
+    private static double? ExtractByPattern(Dictionary<string, Variable> values, string oidPattern)
+    {
+        foreach (var kvp in values)
+        {
+            if (kvp.Key.EndsWith(oidPattern))
+            {
+                return kvp.Value.Data switch
+                {
+                    Gauge32 g32 => (double)g32.ToUInt32(),
+                    Counter32 c32 => (double)c32.ToUInt32(),
+                    Integer32 i32 => (double)i32.ToInt32(),
+                    Counter64 c64 => (double)c64.ToUInt64(),
+                    _ => null
+                };
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts a long value from any OID ending with the given pattern.
+    /// </summary>
+    private static long? ExtractByPatternAsLong(Dictionary<string, Variable> values, string oidPattern)
+    {
+        foreach (var kvp in values)
+        {
+            if (kvp.Key.EndsWith(oidPattern))
+            {
+                return kvp.Value.Data switch
+                {
+                    Integer32 i32 => (long)i32.ToInt32(),
+                    Gauge32 g32 => (long)g32.ToUInt32(),
+                    Counter32 c32 => (long)c32.ToUInt32(),
+                    Counter64 c64 => (long)c64.ToUInt64(),
+                    _ => null
+                };
+            }
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/RavenBench/Metrics/Snmp/SnmpOids.cs
+++ b/src/RavenBench/Metrics/Snmp/SnmpOids.cs
@@ -7,15 +7,16 @@ namespace RavenBench.Metrics.Snmp;
 public static class SnmpOids
 {
     private const string BaseOid = "1.3.6.1.4.1.45751.1.1.1";
+    private const string DatabaseOidPrefix = "1.3.6.1.4.1.45751.1.1.5.2";
 
-    // CPU metrics
+    // CPU metrics (server-wide only)
     [Description("Process CPU usage in %")]
     public const string ProcessCpu = BaseOid + ".5.1";
 
     [Description("Machine CPU usage in %")]
     public const string MachineCpu = BaseOid + ".5.2";
 
-    // Memory metrics
+    // Memory metrics (server-wide only)
     [Description("System-wide allocated memory in MB")]
     public const string TotalMemory = BaseOid + ".6.1";
 
@@ -28,7 +29,7 @@ public static class SnmpOids
     [Description("Dirty memory in MB")]
     public const string DirtyMemory = BaseOid + ".6.6";
 
-    // Load averages (Linux only)
+    // Load averages (Linux only, server-wide)
     [Description("1-minute load average (Linux only)")]
     public const string Load1Min = BaseOid + ".5.6.1";
 
@@ -38,58 +39,117 @@ public static class SnmpOids
     [Description("15-minute load average (Linux only)")]
     public const string Load15Min = BaseOid + ".5.6.3";
 
-    // IO metrics (these are RATES per second, not counters)
-    [Description("IO read operations per second")]
-    public const string IoReadOps = BaseOid + ".10.5";
+    // Server-wide IO metrics (for System database)
+    [Description("IO read operations per second (server-wide)")]
+    public const string ServerIoReadOps = BaseOid + ".10.5";
 
-    [Description("IO write operations per second")]
-    public const string IoWriteOps = BaseOid + ".10.6";
+    [Description("IO write operations per second (server-wide)")]
+    public const string ServerIoWriteOps = BaseOid + ".10.6";
 
-    [Description("Read throughput in kilobytes per second")]
-    public const string IoReadBytes = BaseOid + ".10.7";
+    [Description("Read throughput in kilobytes per second (server-wide)")]
+    public const string ServerIoReadBytes = BaseOid + ".10.7";
 
-    [Description("Write throughput in kilobytes per second")]
-    public const string IoWriteBytes = BaseOid + ".10.8";
+    [Description("Write throughput in kilobytes per second (server-wide)")]
+    public const string ServerIoWriteBytes = BaseOid + ".10.8";
 
-    // Request metrics
-    [Description("Total request count since server startup")]
-    public const string RequestCount = BaseOid + ".7.2";
+    // Server-wide request metrics
+    [Description("Total request count since server startup (server-wide)")]
+    public const string ServerRequestCount = BaseOid + ".7.2";
 
-    [Description("Requests per second (one minute rate)")]
-    public const string RequestsPerSecond = BaseOid + ".7.3";
+    [Description("Requests per second (one minute rate, server-wide)")]
+    public const string ServerRequestsPerSecond = BaseOid + ".7.3";
+
+    // Database-specific OID templates (use string.Format with database index)
+    private const string DbIoReadOps = DatabaseOidPrefix + ".{0}.2.7";
+    private const string DbIoWriteOps = DatabaseOidPrefix + ".{0}.2.8";
+    private const string DbIoReadBytes = DatabaseOidPrefix + ".{0}.2.9";
+    private const string DbIoWriteBytes = DatabaseOidPrefix + ".{0}.2.10";
+    private const string DbRequestCount = DatabaseOidPrefix + ".{0}.3.6";
+    private const string DbRequestsPerSecond = DatabaseOidPrefix + ".{0}.3.5";
 
     /// <summary>
     /// Returns the OID set for the specified SNMP profile.
+    /// When databaseIndex is null, returns server-wide OIDs only.
+    /// When databaseIndex is provided, returns both server-wide OIDs and database-specific OIDs.
     /// </summary>
-    public static IReadOnlyList<string> GetOidsForProfile(SnmpProfile profile)
+    public static IReadOnlyList<string> GetOidsForProfile(SnmpProfile profile, long? databaseIndex = null)
     {
-        return profile switch
+        var oids = new List<string>();
+
+        // Always include server-wide metrics
+        switch (profile)
         {
-            SnmpProfile.Minimal => new[]
+            case SnmpProfile.Minimal:
+                oids.AddRange(new[]
+                {
+                    MachineCpu,
+                    ProcessCpu,
+                    ManagedMemory,
+                    UnmanagedMemory
+                });
+                break;
+            case SnmpProfile.Extended:
+                oids.AddRange(new[]
+                {
+                    MachineCpu,
+                    ProcessCpu,
+                    ManagedMemory,
+                    UnmanagedMemory,
+                    DirtyMemory,
+                    Load1Min,
+                    Load5Min,
+                    Load15Min
+                });
+                break;
+            default:
+                throw new System.ArgumentException($"Unknown SNMP profile: {profile}");
+        }
+
+        // Add database-specific OIDs if database index is provided
+        // Note: IO metrics are ONLY meaningful per-database, not server-wide
+        if (databaseIndex.HasValue && profile == SnmpProfile.Extended)
+        {
+            oids.AddRange(new[]
             {
-                MachineCpu,
-                ProcessCpu,
-                ManagedMemory,
-                UnmanagedMemory
-            },
-            SnmpProfile.Extended => new[]
-            {
-                MachineCpu,
-                ProcessCpu,
-                ManagedMemory,
-                UnmanagedMemory,
-                DirtyMemory,
-                Load1Min,
-                Load5Min,
-                Load15Min,
-                IoReadOps,
-                IoWriteOps,
-                IoReadBytes,
-                IoWriteBytes,
-                RequestCount,
-                RequestsPerSecond
-            },
-            _ => throw new System.ArgumentException($"Unknown SNMP profile: {profile}")
-        };
+                string.Format(DbIoReadOps, databaseIndex.Value),
+                string.Format(DbIoWriteOps, databaseIndex.Value),
+                string.Format(DbIoReadBytes, databaseIndex.Value),
+                string.Format(DbIoWriteBytes, databaseIndex.Value),
+                string.Format(DbRequestCount, databaseIndex.Value),
+                string.Format(DbRequestsPerSecond, databaseIndex.Value)
+            });
+        }
+        // If no database index is provided for Extended profile, skip IO/request metrics
+        // (they're only meaningful in the context of a specific database)
+
+        return oids;
+    }
+
+    /// <summary>
+    /// Attempts to parse the database index from a database-specific SNMP OID.
+    /// OID format: 1.3.6.1.4.1.45751.1.1.5.2.{index}.X.Y
+    /// The database index is at position 11 when split by '.'.
+    /// </summary>
+    /// <param name="oid">The SNMP OID string from the database's @General section</param>
+    /// <param name="databaseIndex">When this method returns, contains the database index if parsing succeeded, or 0 if parsing failed</param>
+    /// <returns>true if the database index was successfully parsed; otherwise, false</returns>
+    public static bool TryParseDatabaseIndexFromOid(string? oid, out long databaseIndex)
+    {
+        databaseIndex = 0;
+
+        if (string.IsNullOrEmpty(oid))
+            return false;
+
+        var parts = oid.Split('.');
+
+        // OID format: 1.3.6.1.4.1.45751.1.1.5.2.{index}.X.Y
+        // Positions:   0 1 2 3 4 5  6    7 8 9 10  11   12 13
+        // The database index is at position 11
+        if (parts.Length >= 12 && long.TryParse(parts[11], out databaseIndex))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/RavenBench/Transport/ITransport.cs
+++ b/src/RavenBench/Transport/ITransport.cs
@@ -34,8 +34,9 @@ public interface ITransport : IDisposable
 
     /// <summary>
     /// Returns SNMP metrics as a structured sample.
+    /// When databaseName is provided, queries database-specific OIDs; otherwise queries server-wide OIDs.
     /// </summary>
-    Task<SnmpSample> GetSnmpMetricsAsync(SnmpOptions snmpOptions);
+    Task<SnmpSample> GetSnmpMetricsAsync(SnmpOptions snmpOptions, string? databaseName = null);
 
     Task<string> GetServerVersionAsync();
     Task<string> GetServerLicenseTypeAsync();

--- a/src/RavenBench/Transport/RawHttpTransport.cs
+++ b/src/RavenBench/Transport/RawHttpTransport.cs
@@ -249,14 +249,72 @@ public sealed class RawHttpTransport : ITransport
         return await RavenServerMetricsCollector.CollectAsync(_baseUrl, _db, HttpHelper.FormatHttpVersion(_httpVersion));
     }
 
-    public async Task<SnmpSample> GetSnmpMetricsAsync(SnmpOptions snmpOptions)
+    public async Task<SnmpSample> GetSnmpMetricsAsync(SnmpOptions snmpOptions, string? databaseName = null)
     {
+        long? databaseIndex = null;
+
+        // Discover database SNMP index if database name is provided
+        if (string.IsNullOrEmpty(databaseName) == false && await TryGetDatabaseSnmpIndexAsync(databaseName) is { } index)
+        {
+            databaseIndex = index;
+        }
+
         var snmpClient = new SnmpClient();
-        var oids = SnmpOids.GetOidsForProfile(snmpOptions.Profile);
+        var oids = SnmpOids.GetOidsForProfile(snmpOptions.Profile, databaseIndex);
         var host = new Uri(_baseUrl).Host;
         var timeoutMs = (int)snmpOptions.Timeout.TotalMilliseconds;
         var snmpResults = await snmpClient.GetManyAsync(oids, host, snmpOptions.Port, SnmpOptions.Community, timeoutMs);
         return SnmpMetricMapper.MapToSample(snmpResults);
+    }
+
+    private async Task<long?> TryGetDatabaseSnmpIndexAsync(string databaseName)
+    {
+        try
+        {
+            var url = $"{_baseUrl}/monitoring/snmp/oids";
+            using var req = CreateRequest(HttpMethod.Get, url);
+
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            resp.EnsureSuccessStatusCode();
+            await using var stream = await resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var doc = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
+
+            // Navigate to Databases section
+            if (doc.RootElement.TryGetProperty("Databases", out var databases) == false)
+            {
+                Console.WriteLine("[WARN] SNMP OID response missing 'Databases' property");
+                return null;
+            }
+
+            // Look for the database by name
+            if (databases.TryGetProperty(databaseName, out var dbElement) == false)
+            {
+                Console.WriteLine($"[WARN] Database '{databaseName}' not found in SNMP OID mapping");
+                return null;
+            }
+
+            // Extract database index from the first OID
+            if (dbElement.TryGetProperty("@General", out var general) == false || general.GetArrayLength() == 0)
+            {
+                Console.WriteLine($"[WARN] No '@General' section or empty for database '{databaseName}'");
+                return null;
+            }
+
+            var firstOid = general[0].GetProperty("OID").GetString();
+            if (SnmpOids.TryParseDatabaseIndexFromOid(firstOid, out var index))
+            {
+                return index;
+            }
+
+            Console.WriteLine($"[WARN] Failed to parse database index from OID: {firstOid}");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[WARN] Failed to discover SNMP database index for '{databaseName}': {ex.Message}");
+            Console.WriteLine("[WARN] Falling back to server-wide SNMP metrics (IO/request metrics will be unavailable)");
+            return null;
+        }
     }
 
     public async Task<string> GetServerVersionAsync()

--- a/tests/RavenBench.Tests/TestTransport.cs
+++ b/tests/RavenBench.Tests/TestTransport.cs
@@ -58,7 +58,7 @@ public sealed class TestTransport : ITransport
 
     public Task<ServerMetrics> GetServerMetricsAsync() => Task.FromResult(_serverMetrics);
 
-    public Task<RavenBench.Metrics.Snmp.SnmpSample> GetSnmpMetricsAsync(RavenBench.Util.SnmpOptions snmpOptions)
+    public Task<RavenBench.Metrics.Snmp.SnmpSample> GetSnmpMetricsAsync(RavenBench.Util.SnmpOptions snmpOptions, string? databaseName = null)
     {
         var sample = new RavenBench.Metrics.Snmp.SnmpSample
         {


### PR DESCRIPTION
Enhances SNMP monitoring to collect database-specific metrics, including IO and request rates, by querying database-specific OIDs.

The changes introduce a mechanism to discover the database index from the RavenDB's SNMP configuration and dynamically construct the appropriate OIDs. This allows for more granular monitoring of individual databases within a RavenDB instance.

Also updates SNMP metrics to use generic OID extraction by pattern matching, supporting both server-wide and database-specific metrics.
