### PR TITLE
Adds bulk writes workload profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,5 @@ FodyWeavers.xsd
 
 # JetBrains IDEs
 .idea/
+
+/epics/

--- a/src/RavenBench/BenchmarkRunner.cs
+++ b/src/RavenBench/BenchmarkRunner.cs
@@ -397,6 +397,7 @@ public class BenchmarkRunner(RunOptions opts)
             WorkloadProfile.Writes => new WriteWorkload(opts.DocumentSizeBytes, startingKey: opts.Preload),
             WorkloadProfile.Reads => BuildReadWorkload(opts, CreateDistribution()),
             WorkloadProfile.QueryById => BuildQueryWorkload(opts, CreateDistribution()),
+            WorkloadProfile.BulkWrites => new BulkWriteWorkload(opts.DocumentSizeBytes, opts.BulkBatchSize, startingKey: opts.Preload),
             _ => throw new NotSupportedException($"Unsupported profile: {opts.Profile}")
         };
     }

--- a/src/RavenBench/Cli/CliParsing.cs
+++ b/src/RavenBench/Cli/CliParsing.cs
@@ -67,7 +67,7 @@ internal static class CliParsing
         };
     }
 
-    private static WorkloadProfile ParseProfile(string? profile)
+    private static WorkloadProfile ParseProfile(string profile)
     {
         if (string.IsNullOrWhiteSpace(profile))
             throw new ArgumentException("--profile is required. Valid options: mixed, writes, reads, query-by-id");
@@ -101,7 +101,7 @@ internal static class CliParsing
         return value;
     }
 
-    private static double? ParseNullableWeight(string? s) => string.IsNullOrWhiteSpace(s) ? null : ParseWeight(s);
+    private static double? ParseNullableWeight(string s) => string.IsNullOrWhiteSpace(s) ? null : ParseWeight(s);
 
     public static (int, int, double) ParseConcurrency(string s)
     {

--- a/src/RavenBench/Cli/RunSettings.cs
+++ b/src/RavenBench/Cli/RunSettings.cs
@@ -27,8 +27,16 @@ public sealed class RunSettings : CommandSettings
     public string? Updates { get; init; }
 
     [CommandOption("--profile")]
-    [Description("Required. Operation profile: mixed, writes, reads, query-by-id")]
+    [Description("Required. Operation profile: mixed, writes, reads, query-by-id, bulk-writes")]
     public string? Profile { get; init; }
+
+    [CommandOption("--bulk-batch-size")]
+    [Description("Number of documents per bulk batch (default: 100)")]
+    public int BulkBatchSize { get; init; } = 100;
+
+    [CommandOption("--bulk-depth")]
+    [Description("Number of batches to send in parallel (default: 1)")]
+    public int BulkDepth { get; init; } = 1;
 
     [CommandOption("--distribution")]
     [Description("Key distribution: uniform, zipfian (default: uniform)")]

--- a/src/RavenBench/Transport/ITransport.cs
+++ b/src/RavenBench/Transport/ITransport.cs
@@ -26,8 +26,8 @@ public readonly struct CalibrationResult(double ttfbMs, double totalMs, long byt
 
 public interface ITransport : IDisposable
 {
-    Task<TransportResult> ExecuteAsync(Operation op, CancellationToken ct);
-    Task PutAsync(string id, string json);
+    Task<TransportResult> ExecuteAsync(OperationBase op, CancellationToken ct);
+    Task PutAsync<T>(string id, T document);
     Task EnsureDatabaseExistsAsync(string databaseName);
     Task<long> GetDocumentCountAsync(string idPrefix);
 

--- a/src/RavenBench/Util/RunOptions.cs
+++ b/src/RavenBench/Util/RunOptions.cs
@@ -56,6 +56,9 @@ public sealed class RunOptions
     // Required workload profile selection
     public WorkloadProfile Profile { get; init; } = WorkloadProfile.Unspecified;
 
+    public int BulkBatchSize { get; init; } = 100;
+    public int BulkDepth { get; init; } = 1;
+
     // Legacy SNMP properties for backwards compatibility - prefer using Snmp property
     public bool SnmpEnabled => Snmp.Enabled;
     public int SnmpPort => Snmp.Port;
@@ -68,5 +71,6 @@ public enum WorkloadProfile
     Mixed,
     Writes,
     Reads,
-    QueryById
+    QueryById,
+    BulkWrites
 }

--- a/src/RavenBench/Workload/BulkWriteWorkload.cs
+++ b/src/RavenBench/Workload/BulkWriteWorkload.cs
@@ -1,0 +1,34 @@
+
+using RavenBench.Util;
+
+namespace RavenBench.Workload;
+
+public sealed class BulkWriteWorkload : IWorkload
+{
+    private readonly int _docSizeBytes;
+    private readonly int _batchSize;
+    private long _maxKey;
+
+    public BulkWriteWorkload(int docSizeBytes, int batchSize, long startingKey = 0)
+    {
+        _docSizeBytes = docSizeBytes;
+        _batchSize = batchSize;
+        _maxKey = startingKey;
+    }
+
+    public OperationBase NextOperation(Random rng)
+    {
+        var documents = new List<DocumentToWrite<string>>();
+        for (int i = 0; i < _batchSize; i++)
+        {
+            var keyValue = Interlocked.Increment(ref _maxKey);
+            var id = IdFor(keyValue);
+            var payload = PayloadGenerator.Generate(_docSizeBytes, rng);
+            documents.Add(new DocumentToWrite<string> { Id = id, Document = payload });
+        }
+
+        return new BulkInsertOperation<string> { Documents = documents };
+    }
+
+    private static string IdFor(long i) => $"bench/{i:D8}";
+}

--- a/src/RavenBench/Workload/DocumentToWrite.cs
+++ b/src/RavenBench/Workload/DocumentToWrite.cs
@@ -1,0 +1,7 @@
+namespace RavenBench.Workload;
+
+public class DocumentToWrite<T>
+{
+    public required string Id { get; init; }
+    public required T Document { get; init; }
+}

--- a/src/RavenBench/Workload/IWorkload.cs
+++ b/src/RavenBench/Workload/IWorkload.cs
@@ -1,21 +1,40 @@
+using System.Collections.Generic;
+
 namespace RavenBench.Workload;
 
 public interface IWorkload
 {
-    Operation NextOperation(Random rng);
+    OperationBase NextOperation(Random rng);
 }
 
-public enum OperationType
+public abstract class OperationBase
 {
-    ReadById,
-    Insert,
-    Update,
-    Query
 }
 
-public readonly struct Operation(OperationType type, string id, string? payload)
+public class ReadOperation : OperationBase
 {
-    public OperationType Type { get; } = type;
-    public string Id { get; } = id;
-    public string? Payload { get; } = payload;
+    public required string Id { get; init; }
 }
+
+public class QueryOperation : OperationBase
+{
+    public required string Id { get; init; }
+}
+
+public class InsertOperation<T> : OperationBase
+{
+    public required string Id { get; init; }
+    public required T Payload { get; init; }
+}
+
+public class UpdateOperation<T> : OperationBase
+{
+    public required string Id { get; init; }
+    public required T Payload { get; init; }
+}
+
+public class BulkInsertOperation<T> : OperationBase
+{
+    public required List<DocumentToWrite<T>> Documents { get; init; }
+}
+

--- a/src/RavenBench/Workload/QueryWorkload.cs
+++ b/src/RavenBench/Workload/QueryWorkload.cs
@@ -14,10 +14,10 @@ public sealed class QueryWorkload : IWorkload
         _maxKey = initialKeyspace;
     }
 
-    public Operation NextOperation(Random rng)
+    public OperationBase NextOperation(Random rng)
     {
         var k = _distribution.NextKey(rng, (int)Math.Min(_maxKey, int.MaxValue));
-        return new Operation(OperationType.Query, IdFor(k), payload: null);
+        return new QueryOperation { Id = IdFor(k) };
     }
 
     private static string IdFor(long i) => $"bench/{i:D8}";

--- a/src/RavenBench/Workload/ReadWorkload.cs
+++ b/src/RavenBench/Workload/ReadWorkload.cs
@@ -14,10 +14,10 @@ public sealed class ReadWorkload : IWorkload
         _maxKey = initialKeyspace;
     }
 
-    public Operation NextOperation(Random rng)
+    public OperationBase NextOperation(Random rng)
     {
         var k = _distribution.NextKey(rng, (int)Math.Min(_maxKey, int.MaxValue));
-        return new Operation(OperationType.ReadById, IdFor(k), payload: null);
+        return new ReadOperation { Id = IdFor(k) };
     }
 
     private static string IdFor(long i) => $"bench/{i:D8}";

--- a/src/RavenBench/Workload/WriteWorkload.cs
+++ b/src/RavenBench/Workload/WriteWorkload.cs
@@ -13,12 +13,12 @@ public sealed class WriteWorkload : IWorkload
         _maxKey = startingKey;
     }
 
-    public Operation NextOperation(Random rng)
+    public OperationBase NextOperation(Random rng)
     {
         var keyValue = Interlocked.Increment(ref _maxKey);
         var id = IdFor(keyValue);
         var payload = PayloadGenerator.Generate(_docSizeBytes, rng);
-        return new Operation(OperationType.Insert, id, payload);
+        return new InsertOperation<string> { Id = id, Payload = payload };
     }
 
     private static string IdFor(long i) => $"bench/{i:D8}";

--- a/tests/RavenBench.Tests/IntegrationTests.cs
+++ b/tests/RavenBench.Tests/IntegrationTests.cs
@@ -92,16 +92,19 @@ public class IntegrationTests
             var op = workload.NextOperation(rng);
             
             op.Should().NotBeNull();
-            op.Type.Should().NotBe(OperationType.ReadById); // Should be write since 100% writes
-            
-            if (op.Payload != null)
+            op.Should().BeOfType<InsertOperation<string>>(); // Should be write since 100% writes
+
+            if (op is InsertOperation<string> insertOp)
             {
+                var payloadString = insertOp.Payload;
+                payloadString.Should().NotBeNull();
+
                 // Payload should be valid JSON
-                var document = System.Text.Json.JsonDocument.Parse(op.Payload);
+                var document = System.Text.Json.JsonDocument.Parse(payloadString);
                 document.RootElement.ValueKind.Should().Be(System.Text.Json.JsonValueKind.Object);
-                
+
                 // Should be reasonably sized
-                var payloadBytes = System.Text.Encoding.UTF8.GetByteCount(op.Payload);
+                var payloadBytes = System.Text.Encoding.UTF8.GetByteCount(payloadString);
                 payloadBytes.Should().BeGreaterThan(100);
                 payloadBytes.Should().BeLessThan(5000); // Within reasonable bounds for 2KB target
             }

--- a/tests/RavenBench.Tests/TestTransport.cs
+++ b/tests/RavenBench.Tests/TestTransport.cs
@@ -39,13 +39,13 @@ public sealed class TestTransport : ITransport
 
     public void Dispose() { }
 
-    public async Task<TransportResult> ExecuteAsync(Operation op, CancellationToken ct)
+    public async Task<TransportResult> ExecuteAsync(OperationBase op, CancellationToken ct)
     {
         await Task.Delay(_baseLatencyMs, ct);
         return new TransportResult(bytesOut: 200, bytesIn: 150);
     }
 
-    public Task PutAsync(string id, string json) => Task.CompletedTask;
+    public Task PutAsync<T>(string id, T document) => Task.CompletedTask;
 
     public Task EnsureDatabaseExistsAsync(string databaseName) => Task.CompletedTask;
 


### PR DESCRIPTION
Adds a new "bulk-writes" workload profile to the benchmark runner.

This profile allows sending documents in batches, controlled by `--bulk-batch-size` and `--bulk-depth` parameters.

Also refactors transport execution to use operation objects instead of enum values.
