### PR TITLE
Adds StackOverflow dataset support

### DIFF
--- a/src/RavenBench/Cli/RunCommand.cs
+++ b/src/RavenBench/Cli/RunCommand.cs
@@ -10,9 +10,19 @@ public sealed class RunCommand : AsyncCommand<RunSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, RunSettings settings)
     {
-        if (string.IsNullOrWhiteSpace(settings.Url) || string.IsNullOrWhiteSpace(settings.Database))
+        // Validate URL (always required)
+        if (string.IsNullOrWhiteSpace(settings.Url))
         {
-            AnsiConsole.MarkupLine("[red]--url and --database are required.[/]");
+            AnsiConsole.MarkupLine("[red]--url is required.[/]");
+            return -1;
+        }
+
+        // Database is optional when using dataset (will be auto-generated)
+        if (string.IsNullOrWhiteSpace(settings.Database) &&
+            string.IsNullOrWhiteSpace(settings.Dataset) &&
+            string.IsNullOrWhiteSpace(settings.DatasetProfile))
+        {
+            AnsiConsole.MarkupLine("[red]--database is required (or use --dataset with --dataset-profile to auto-generate).[/]");
             return -1;
         }
         var opts = settings.ToRunOptions();

--- a/src/RavenBench/Cli/RunSettings.cs
+++ b/src/RavenBench/Cli/RunSettings.cs
@@ -38,6 +38,26 @@ public sealed class RunSettings : CommandSettings
     [Description("Number of batches to send in parallel (default: 1)")]
     public int BulkDepth { get; init; } = 1;
 
+    [CommandOption("--dataset")]
+    [Description("Dataset to import: stackoverflow (auto-downloads and imports)")]
+    public string? Dataset { get; init; }
+
+    [CommandOption("--dataset-profile")]
+    [Description("Dataset size profile: small (~5GB), half (~20GB), full (~50GB) - automatically sets database name and size")]
+    public string? DatasetProfile { get; init; }
+
+    [CommandOption("--dataset-size")]
+    [Description("Custom dataset size: 0=full, N=use N post dump files (overridden by --dataset-profile)")]
+    public int DatasetSize { get; init; } = 0;
+
+    [CommandOption("--dataset-skip-if-exists")]
+    [Description("Skip dataset import if data already exists (default: true)")]
+    public bool DatasetSkipIfExists { get; init; } = true;
+
+    [CommandOption("--dataset-cache-dir")]
+    [Description("Directory for caching downloaded dataset files")]
+    public string? DatasetCacheDir { get; init; }
+
     [CommandOption("--distribution")]
     [Description("Key distribution: uniform, zipfian (default: uniform)")]
     public string Distribution { get; init; } = "uniform";

--- a/src/RavenBench/Dataset/DatasetInfo.cs
+++ b/src/RavenBench/Dataset/DatasetInfo.cs
@@ -1,0 +1,167 @@
+namespace RavenBench.Dataset;
+
+/// <summary>
+/// Metadata about a known dataset that can be downloaded and imported.
+/// </summary>
+public sealed class DatasetInfo
+{
+    public required string Name { get; init; }
+    public required string Description { get; init; }
+    public required List<DatasetFile> Files { get; init; }
+    public required int MaxQuestionId { get; init; }
+    public required int MaxUserId { get; init; }
+}
+
+/// <summary>
+/// A single dump file that can be downloaded and imported independently.
+/// </summary>
+public sealed class DatasetFile
+{
+    public required string FileName { get; init; }
+    public required string Url { get; init; }
+    public required string Type { get; init; } // "indexes", "users", "questions", "posts"
+    public required long EstimatedSizeBytes { get; init; }
+    public string? Description { get; init; }
+}
+
+/// <summary>
+/// Dataset size profile for predefined configurations.
+/// </summary>
+public enum DatasetProfile
+{
+    Small,  // ~5GB: 5 post dumps + users
+    Half,   // ~20GB: 20 post dumps + users
+    Full    // ~50GB: Complete dataset
+}
+
+/// <summary>
+/// Known dataset definitions.
+/// </summary>
+public static class KnownDatasets
+{
+    private const string S3Base = "https://stackoverflow-dump.s3.dualstack.us-west-2.amazonaws.com";
+
+    /// <summary>
+    /// Gets recommended database name for a dataset profile.
+    /// </summary>
+    public static string GetDatabaseName(DatasetProfile profile)
+    {
+        return profile switch
+        {
+            DatasetProfile.Small => "StackOverflow-5GB",   // 5 post dumps
+            DatasetProfile.Half => "StackOverflow-20GB",   // 20 post dumps
+            DatasetProfile.Full => "StackOverflow-50GB",   // Full dataset
+            _ => throw new ArgumentException($"Unknown profile: {profile}")
+        };
+    }
+
+    /// <summary>
+    /// Gets database name for a custom dataset size (post dump count).
+    /// </summary>
+    public static string GetDatabaseNameForSize(int postDumpCount)
+    {
+        if (postDumpCount == 0)
+            return "StackOverflow-50GB"; // Full dataset
+
+        // Each post dump is roughly 1GB, plus ~2GB for users
+        var estimatedGb = postDumpCount + 2;
+        return $"StackOverflow-{estimatedGb}GB";
+    }
+
+    /// <summary>
+    /// Gets dataset size (post dump count) for a profile.
+    /// </summary>
+    public static int GetDatasetSize(DatasetProfile profile)
+    {
+        return profile switch
+        {
+            DatasetProfile.Small => 5,
+            DatasetProfile.Half => 20,
+            DatasetProfile.Full => 0, // 0 = full dataset
+            _ => throw new ArgumentException($"Unknown profile: {profile}")
+        };
+    }
+
+    public static DatasetInfo StackOverflow => new()
+    {
+        Name = "StackOverflow",
+        Description = "StackOverflow dataset from June 2022 with questions, users, and posts",
+        MaxQuestionId = 12350817,
+        MaxUserId = 5987285,
+        Files = new List<DatasetFile>
+        {
+            new DatasetFile
+            {
+                FileName = "StackExchange-Indexes.ravendbdump",
+                Url = $"{S3Base}/StackExchange-Indexes.ravendbdump",
+                Type = "indexes",
+                EstimatedSizeBytes = 100 * 1024 * 1024, // ~100 MB
+                Description = "Index definitions for StackExchange data"
+            },
+            new DatasetFile
+            {
+                FileName = "StackOverflow-2022-06-06.ravendbdump",
+                Url = $"{S3Base}/StackOverflow-2022-06-06.ravendbdump",
+                Type = "full",
+                EstimatedSizeBytes = 50L * 1024 * 1024 * 1024, // ~50 GB
+                Description = "Complete StackOverflow dataset snapshot from June 2022"
+            }
+        }
+    };
+
+    public static DatasetInfo StackOverflowPartial(int postDumpCount) => new()
+    {
+        Name = "StackOverflow-Partial",
+        Description = $"Partial StackOverflow dataset with users and {postDumpCount} post dump files",
+        MaxQuestionId = 12350817,
+        MaxUserId = 5987285,
+        Files = GeneratePartialFiles(postDumpCount)
+    };
+
+    private static List<DatasetFile> GeneratePartialFiles(int postDumpCount)
+    {
+        var files = new List<DatasetFile>
+        {
+            // Index definitions must be imported first
+            new DatasetFile
+            {
+                FileName = "Stackoverflow.indexes-dump",
+                Url = $"{S3Base}/Stackoverflow.indexes-dump",
+                Type = "indexes",
+                EstimatedSizeBytes = 10 * 1024 * 1024, // ~10 MB
+                Description = "Index definitions"
+            },
+            new DatasetFile
+            {
+                FileName = "users.dump",
+                Url = $"{S3Base}/users.dump",
+                Type = "users",
+                EstimatedSizeBytes = 2L * 1024 * 1024 * 1024, // ~2 GB
+                Description = "User data"
+            }
+        };
+
+        for (int i = 1; i <= postDumpCount && i <= 45; i++)
+        {
+            files.Add(new DatasetFile
+            {
+                FileName = $"posts-{i:D3}.dump",
+                Url = $"{S3Base}/posts-{i:D3}.dump",
+                Type = "posts",
+                EstimatedSizeBytes = 1024L * 1024 * 1024, // ~1 GB each
+                Description = $"Post data part {i}"
+            });
+        }
+
+        return files;
+    }
+
+    public static DatasetInfo? GetByName(string name)
+    {
+        return name.ToLowerInvariant() switch
+        {
+            "stackoverflow" => StackOverflow,
+            _ => null
+        };
+    }
+}

--- a/src/RavenBench/Dataset/DatasetManager.cs
+++ b/src/RavenBench/Dataset/DatasetManager.cs
@@ -1,0 +1,242 @@
+using System.Net.Http;
+using System.IO;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+
+namespace RavenBench.Dataset;
+
+/// <summary>
+/// Manages dataset download, caching, and import into RavenDB.
+/// </summary>
+public sealed class DatasetManager
+{
+    private readonly string _cacheDir;
+    private readonly HttpClient _httpClient;
+    private readonly Dictionary<string, IDatasetProvider> _providers;
+
+    public DatasetManager(string? cacheDir = null)
+    {
+        _cacheDir = cacheDir ?? Path.Combine(Path.GetTempPath(), "RavenBench", "datasets");
+        Directory.CreateDirectory(_cacheDir);
+        _httpClient = new HttpClient { Timeout = TimeSpan.FromHours(2) };
+
+        // Register known dataset providers
+        _providers = new Dictionary<string, IDatasetProvider>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "stackoverflow", new StackOverflowDatasetProvider() }
+        };
+    }
+
+    /// <summary>
+    /// Gets a dataset provider by name, or null if not found.
+    /// </summary>
+    public IDatasetProvider? GetProvider(string datasetName)
+    {
+        return _providers.TryGetValue(datasetName, out var provider) ? provider : null;
+    }
+
+    /// <summary>
+    /// Downloads a dataset file if not already cached.
+    /// </summary>
+    public async Task<string> DownloadAsync(DatasetFile file, IProgress<double>? progress = null, CancellationToken ct = default)
+    {
+        var localPath = Path.Combine(_cacheDir, file.FileName);
+
+        // Check if already downloaded
+        if (File.Exists(localPath))
+        {
+            Console.WriteLine($"[Dataset] Using cached {file.FileName}");
+            return localPath;
+        }
+
+        Console.WriteLine($"[Dataset] Downloading {file.FileName} from {file.Url}");
+        Console.WriteLine($"[Dataset] Estimated size: {FormatBytes(file.EstimatedSizeBytes)}");
+
+        using var response = await _httpClient.GetAsync(file.Url, HttpCompletionOption.ResponseHeadersRead, ct);
+        response.EnsureSuccessStatusCode();
+
+        var totalBytes = response.Content.Headers.ContentLength ?? file.EstimatedSizeBytes;
+        var downloadedBytes = 0L;
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(ct);
+        await using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, useAsync: true);
+
+        var buffer = new byte[8192];
+        int bytesRead;
+        var lastProgressReport = DateTime.UtcNow;
+
+        while ((bytesRead = await contentStream.ReadAsync(buffer, ct)) > 0)
+        {
+            await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
+            downloadedBytes += bytesRead;
+
+            // Report progress every 2 seconds
+            if (DateTime.UtcNow - lastProgressReport > TimeSpan.FromSeconds(2))
+            {
+                var progressPct = totalBytes > 0 ? (double)downloadedBytes / totalBytes * 100 : 0;
+                Console.WriteLine($"[Dataset] Downloaded {FormatBytes(downloadedBytes)} / {FormatBytes(totalBytes)} ({progressPct:F1}%)");
+                progress?.Report(progressPct);
+                lastProgressReport = DateTime.UtcNow;
+            }
+        }
+
+        Console.WriteLine($"[Dataset] Download complete: {file.FileName}");
+        return localPath;
+    }
+
+    /// <summary>
+    /// Ensures a database exists on the server.
+    /// </summary>
+    private async Task EnsureDatabaseExistsAsync(string serverUrl, string databaseName, CancellationToken ct = default)
+    {
+        using var store = new DocumentStore
+        {
+            Urls = new[] { serverUrl }
+        };
+        store.Initialize();
+
+        var dbRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName), ct);
+        if (dbRecord == null)
+        {
+            Console.WriteLine($"[Dataset] Creating database '{databaseName}'");
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(databaseName)), ct);
+        }
+    }
+
+    /// <summary>
+    /// Imports a RavenDB dump file into the specified database using Smuggler API.
+    /// </summary>
+    public async Task ImportDumpAsync(string dumpFilePath, string serverUrl, string databaseName, CancellationToken ct = default)
+    {
+        Console.WriteLine($"[Dataset] Importing {Path.GetFileName(dumpFilePath)} into database '{databaseName}'");
+
+        // Ensure database exists before importing
+        await EnsureDatabaseExistsAsync(serverUrl, databaseName, ct);
+
+        using var store = new DocumentStore
+        {
+            Urls = new[] { serverUrl },
+            Database = databaseName
+        };
+        store.Initialize();
+
+        var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), dumpFilePath, ct);
+
+        Console.WriteLine($"[Dataset] Import operation started");
+
+        // Wait for operation to complete (Smuggler.ImportAsync returns Operation<SmugglerResult>)
+        try
+        {
+            await operation.WaitForCompletionAsync();
+            Console.WriteLine($"[Dataset] Import completed successfully");
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Import failed: {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Downloads and imports a complete dataset.
+    /// </summary>
+    public async Task ImportDatasetAsync(DatasetInfo dataset, string serverUrl, string databaseName, CancellationToken ct = default)
+    {
+        Console.WriteLine($"[Dataset] Importing dataset '{dataset.Name}' into database '{databaseName}'");
+        Console.WriteLine($"[Dataset] {dataset.Description}");
+        Console.WriteLine($"[Dataset] Files to import: {dataset.Files.Count}");
+
+        foreach (var file in dataset.Files)
+        {
+            // Download
+            var localPath = await DownloadAsync(file, progress: null, ct);
+
+            // Import
+            await ImportDumpAsync(localPath, serverUrl, databaseName, ct);
+        }
+
+        Console.WriteLine($"[Dataset] Dataset '{dataset.Name}' import complete");
+    }
+
+    /// <summary>
+    /// Checks if the StackOverflow dataset appears to be already imported by checking
+    /// for questions and users collections with minimum document counts.
+    /// </summary>
+    public async Task<bool> IsStackOverflowDatasetImportedAsync(string serverUrl, string databaseName, int expectedMinDocuments = 1000)
+    {
+        try
+        {
+            using var store = new DocumentStore
+            {
+                Urls = new[] { serverUrl }
+            };
+            store.Initialize();
+
+            // First check if database exists
+            var dbRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+            if (dbRecord == null)
+            {
+                Console.WriteLine($"[Dataset] Database '{databaseName}' does not exist");
+                return false;
+            }
+
+            // Check document counts
+            store.Database = databaseName;
+            var stats = await store.Maintenance.SendAsync(new Raven.Client.Documents.Operations.GetStatisticsOperation());
+
+            if (stats.CountOfDocuments < expectedMinDocuments)
+            {
+                Console.WriteLine($"[Dataset] Database '{databaseName}' exists but has only {stats.CountOfDocuments} documents (expected >= {expectedMinDocuments})");
+                return false;
+            }
+
+            // Verify it has the expected collections
+            using var session = store.OpenAsyncSession();
+            var questionsExist = await session.Advanced.AsyncRawQuery<object>("from questions")
+                .Take(1)
+                .AnyAsync();
+
+            var usersExist = await session.Advanced.AsyncRawQuery<object>("from users")
+                .Take(1)
+                .AnyAsync();
+
+            if (!questionsExist || !usersExist)
+            {
+                Console.WriteLine($"[Dataset] Database '{databaseName}' exists but missing expected collections (questions: {questionsExist}, users: {usersExist})");
+                return false;
+            }
+
+            Console.WriteLine($"[Dataset] Database '{databaseName}' already has {stats.CountOfDocuments} documents with expected collections");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Dataset] Error checking if dataset exists: {ex.Message}");
+            return false;
+        }
+    }
+
+    public void ClearCache()
+    {
+        if (Directory.Exists(_cacheDir))
+        {
+            Console.WriteLine($"[Dataset] Clearing cache directory: {_cacheDir}");
+            Directory.Delete(_cacheDir, recursive: true);
+        }
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] sizes = { "B", "KB", "MB", "GB", "TB" };
+        double len = bytes;
+        int order = 0;
+        while (len >= 1024 && order < sizes.Length - 1)
+        {
+            order++;
+            len /= 1024;
+        }
+        return $"{len:0.##} {sizes[order]}";
+    }
+}

--- a/src/RavenBench/Dataset/IDatasetProvider.cs
+++ b/src/RavenBench/Dataset/IDatasetProvider.cs
@@ -1,0 +1,30 @@
+namespace RavenBench.Dataset;
+
+/// <summary>
+/// Interface for dataset-specific operations including download, import, and verification.
+/// Each dataset (StackOverflow, Northwind, etc.) should implement this interface.
+/// </summary>
+public interface IDatasetProvider
+{
+    /// <summary>
+    /// The name of this dataset (e.g., "stackoverflow", "northwind").
+    /// </summary>
+    string DatasetName { get; }
+
+    /// <summary>
+    /// Gets the dataset information for a specific size profile or configuration.
+    /// </summary>
+    DatasetInfo GetDatasetInfo(string? profile = null, int? customSize = null);
+
+    /// <summary>
+    /// Determines the target database name based on size profile or custom size.
+    /// Different sizes should use different databases to avoid conflicts.
+    /// </summary>
+    string GetDatabaseName(string? profile = null, int? customSize = null);
+
+    /// <summary>
+    /// Checks if this dataset is already imported in the specified database.
+    /// Should verify expected collections and document counts exist.
+    /// </summary>
+    Task<bool> IsDatasetImportedAsync(string serverUrl, string databaseName, int expectedMinDocuments = 1000);
+}

--- a/src/RavenBench/Dataset/StackOverflowDatasetProvider.cs
+++ b/src/RavenBench/Dataset/StackOverflowDatasetProvider.cs
@@ -1,0 +1,102 @@
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.ServerWide.Operations;
+
+namespace RavenBench.Dataset;
+
+/// <summary>
+/// Dataset provider for StackOverflow data with questions and users collections.
+/// </summary>
+public class StackOverflowDatasetProvider : IDatasetProvider
+{
+    public string DatasetName => "stackoverflow";
+
+    public DatasetInfo GetDatasetInfo(string? profile = null, int? customSize = null)
+    {
+        if (string.IsNullOrEmpty(profile) == false)
+        {
+            var parsedProfile = Enum.Parse<DatasetProfile>(profile, ignoreCase: true);
+            var size = KnownDatasets.GetDatasetSize(parsedProfile);
+            return KnownDatasets.StackOverflowPartial(size);
+        }
+        else if (customSize.HasValue)
+        {
+            return KnownDatasets.StackOverflowPartial(customSize.Value);
+        }
+        else
+        {
+            return KnownDatasets.StackOverflow;
+        }
+    }
+
+    public string GetDatabaseName(string? profile = null, int? customSize = null)
+    {
+        if (string.IsNullOrEmpty(profile) == false)
+        {
+            var parsedProfile = Enum.Parse<DatasetProfile>(profile, ignoreCase: true);
+            return KnownDatasets.GetDatabaseName(parsedProfile);
+        }
+        else if (customSize.HasValue)
+        {
+            return KnownDatasets.GetDatabaseNameForSize(customSize.Value);
+        }
+        else
+        {
+            return "StackOverflow";
+        }
+    }
+
+    public async Task<bool> IsDatasetImportedAsync(string serverUrl, string databaseName, int expectedMinDocuments = 1000)
+    {
+        try
+        {
+            using var store = new DocumentStore
+            {
+                Urls = new[] { serverUrl }
+            };
+            store.Initialize();
+
+            // First check if database exists
+            var dbRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+            if (dbRecord == null)
+            {
+                Console.WriteLine($"[Dataset] Database '{databaseName}' does not exist");
+                return false;
+            }
+
+            // Check document counts
+            store.Database = databaseName;
+            var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+
+            if (stats.CountOfDocuments < expectedMinDocuments)
+            {
+                Console.WriteLine($"[Dataset] Database '{databaseName}' exists but has only {stats.CountOfDocuments} documents (expected >= {expectedMinDocuments})");
+                return false;
+            }
+
+            // Verify StackOverflow-specific collections: questions and users
+            using var session = store.OpenAsyncSession();
+            var questionsExist = await session.Advanced.AsyncRawQuery<object>("from questions")
+                .Take(1)
+                .AnyAsync();
+
+            var usersExist = await session.Advanced.AsyncRawQuery<object>("from users")
+                .Take(1)
+                .AnyAsync();
+
+            if (!questionsExist || !usersExist)
+            {
+                Console.WriteLine($"[Dataset] Database '{databaseName}' exists but missing expected collections (questions: {questionsExist}, users: {usersExist})");
+                return false;
+            }
+
+            Console.WriteLine($"[Dataset] Database '{databaseName}' already has {stats.CountOfDocuments} documents with expected collections");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Dataset] Error checking if dataset exists: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/src/RavenBench/Reporting/JsonResultsWriter.cs
+++ b/src/RavenBench/Reporting/JsonResultsWriter.cs
@@ -14,7 +14,7 @@ public static class JsonResultsWriter
     public static void Write(string path, BenchmarkSummary summary)
     {
         var dir = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(dir))
+        if (string.IsNullOrEmpty(dir) == false)
             Directory.CreateDirectory(dir);
         using var fs = File.Create(path);
         JsonSerializer.Serialize(fs, summary, Options);

--- a/src/RavenBench/Util/RunOptions.cs
+++ b/src/RavenBench/Util/RunOptions.cs
@@ -59,6 +59,13 @@ public sealed class RunOptions
     public int BulkBatchSize { get; init; } = 100;
     public int BulkDepth { get; init; } = 1;
 
+    // Dataset management
+    public string? Dataset { get; init; }
+    public string? DatasetProfile { get; init; } // small, half, full - automatically sets database name and size
+    public int DatasetSize { get; init; } = 0; // 0 = full dataset, N = use N post dump files for partial (overridden by DatasetProfile)
+    public bool DatasetSkipIfExists { get; init; } = true; // Skip import if dataset appears to exist
+    public string? DatasetCacheDir { get; init; }
+
     // Legacy SNMP properties for backwards compatibility - prefer using Snmp property
     public bool SnmpEnabled => Snmp.Enabled;
     public int SnmpPort => Snmp.Port;
@@ -72,5 +79,7 @@ public enum WorkloadProfile
     Writes,
     Reads,
     QueryById,
-    BulkWrites
+    BulkWrites,
+    StackOverflowReads,
+    StackOverflowQueries
 }

--- a/src/RavenBench/Workload/StackOverflowQueryWorkload.cs
+++ b/src/RavenBench/Workload/StackOverflowQueryWorkload.cs
@@ -1,0 +1,30 @@
+namespace RavenBench.Workload;
+
+/// <summary>
+/// Workload replicating consistent-questions.lua pattern:
+/// Parameterized queries against questions collection using sampled document IDs
+/// </summary>
+public sealed class StackOverflowQueryWorkload : IWorkload
+{
+    private readonly int[] _questionIds;
+
+    /// <summary>
+    /// Creates a StackOverflow query workload using sampled question IDs.
+    /// </summary>
+    /// <param name="metadata">Workload metadata containing sampled document IDs</param>
+    public StackOverflowQueryWorkload(StackOverflowWorkloadMetadata metadata)
+    {
+        if (metadata.QuestionIds.Length == 0)
+        {
+            throw new ArgumentException("Metadata must contain sampled question IDs");
+        }
+
+        _questionIds = metadata.QuestionIds;
+    }
+
+    public OperationBase NextOperation(Random rng)
+    {
+        var questionId = _questionIds[rng.Next(_questionIds.Length)];
+        return new QueryOperation { Id = $"questions/{questionId}" };
+    }
+}

--- a/src/RavenBench/Workload/StackOverflowReadWorkload.cs
+++ b/src/RavenBench/Workload/StackOverflowReadWorkload.cs
@@ -1,0 +1,41 @@
+namespace RavenBench.Workload;
+
+/// <summary>
+/// Workload replicating full-random-reads.lua pattern:
+/// Random reads from questions/{id} or users/{id} (50/50 mix) using sampled document IDs
+/// </summary>
+public sealed class StackOverflowReadWorkload : IWorkload
+{
+    private readonly int[] _questionIds;
+    private readonly int[] _userIds;
+
+    /// <summary>
+    /// Creates a StackOverflow read workload using sampled document IDs.
+    /// </summary>
+    /// <param name="metadata">Workload metadata containing sampled document IDs</param>
+    public StackOverflowReadWorkload(StackOverflowWorkloadMetadata metadata)
+    {
+        if (metadata.QuestionIds.Length == 0 || metadata.UserIds.Length == 0)
+        {
+            throw new ArgumentException("Metadata must contain sampled question and user IDs");
+        }
+
+        _questionIds = metadata.QuestionIds;
+        _userIds = metadata.UserIds;
+    }
+
+    public OperationBase NextOperation(Random rng)
+    {
+        // 50/50 split between questions and users (matching full-random-reads.lua)
+        if (rng.Next(2) == 0)
+        {
+            var questionId = _questionIds[rng.Next(_questionIds.Length)];
+            return new ReadOperation { Id = $"questions/{questionId}" };
+        }
+        else
+        {
+            var userId = _userIds[rng.Next(_userIds.Length)];
+            return new ReadOperation { Id = $"users/{userId}" };
+        }
+    }
+}

--- a/src/RavenBench/Workload/StackOverflowWorkloadMetadata.cs
+++ b/src/RavenBench/Workload/StackOverflowWorkloadMetadata.cs
@@ -1,0 +1,156 @@
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using System.Linq;
+
+namespace RavenBench.Workload;
+
+/// <summary>
+/// Workload-specific metadata for StackOverflow profiles.
+/// Stores sampled document IDs to avoid requesting non-existent documents during benchmarks.
+/// </summary>
+public sealed class StackOverflowWorkloadMetadata
+{
+    public int[] QuestionIds { get; set; } = Array.Empty<int>();
+    public int[] UserIds { get; set; } = Array.Empty<int>();
+    public long QuestionCount { get; set; }
+    public long UserCount { get; set; }
+    public DateTime ComputedAt { get; set; }
+}
+
+/// <summary>
+/// Helper for discovering and caching StackOverflow workload metadata (sampled document IDs).
+/// This is workload-specific logic, not dataset-specific, per PRD architecture.
+/// </summary>
+public static class StackOverflowWorkloadHelper
+{
+    private const string MetadataDocId = "workload/stackoverflow-metadata";
+    private const int DefaultSampleSize = 10000;
+
+    /// <summary>
+    /// Discovers actual document IDs by sampling the database and caches them for workload use.
+    /// Returns sampled question and user IDs that exist in the database.
+    /// </summary>
+    public static async Task<StackOverflowWorkloadMetadata> DiscoverOrLoadMetadataAsync(
+        string serverUrl,
+        string databaseName,
+        int sampleSize = DefaultSampleSize)
+    {
+        using var store = new DocumentStore
+        {
+            Urls = new[] { serverUrl },
+            Database = databaseName
+        };
+        store.Initialize();
+
+        // Check if we have cached metadata
+        using var session = store.OpenAsyncSession();
+        var cached = await session.LoadAsync<StackOverflowWorkloadMetadata>(MetadataDocId);
+
+        if (cached != null && cached.QuestionIds.Length > 0 && cached.UserIds.Length > 0)
+        {
+            Console.WriteLine($"[Workload] Using cached StackOverflow metadata: {cached.QuestionIds.Length} questions, {cached.UserIds.Length} users");
+            return cached;
+        }
+
+        Console.WriteLine("[Workload] Discovering StackOverflow document IDs by sampling database...");
+
+        // Sample actual document IDs from the database
+        var questionIds = await SampleDocumentIdsAsync(store, "questions", sampleSize);
+        var userIds = await SampleDocumentIdsAsync(store, "users", sampleSize);
+
+        if (questionIds.Count() == 0 || userIds.Count() == 0)
+        {
+            throw new InvalidOperationException(
+                $"Failed to discover StackOverflow document IDs. Found {questionIds.Count} questions, {userIds.Count} users. " +
+                "Ensure the StackOverflow dataset is imported before running benchmarks.");
+        }
+
+        Console.WriteLine($"[Workload] Sampled {questionIds.Count()} questions, {userIds.Count()} users");
+
+        // Store metadata for future use
+        var metadata = new StackOverflowWorkloadMetadata
+        {
+            QuestionIds = questionIds.ToArray(),
+            UserIds = userIds.ToArray(),
+            QuestionCount = questionIds.Count(),
+            UserCount = userIds.Count(),
+            ComputedAt = DateTime.UtcNow
+        };
+
+        await session.StoreAsync(metadata, MetadataDocId);
+        await session.SaveChangesAsync();
+        Console.WriteLine("[Workload] Stored StackOverflow workload metadata in database");
+
+        return metadata;
+    }
+
+    /// <summary>
+    /// Samples document IDs from a collection using RavenDB's random() ordering.
+    /// Returns a list of actual document IDs that exist in the database.
+    /// Uses a deterministic seed for reproducibility.
+    /// </summary>
+    private static async Task<HashSet<int>> SampleDocumentIdsAsync(
+        IDocumentStore store,
+        string collection,
+        int sampleSize)
+    {
+        var ids = new HashSet<int>();
+
+        using var session = store.OpenAsyncSession();
+
+        // Use RavenDB's built-in random() ordering with a fixed seed for deterministic sampling
+        // This is much more efficient than streaming all documents
+        var seed = "ravenbench-sampling-seed";
+        var query = session.Advanced.AsyncRawQuery<dynamic>($"from {collection} order by random('{seed}') limit {sampleSize} select id()")
+            .WaitForNonStaleResults(); // Ensure we're reading from non-stale indexes
+
+        await using var stream = await session.Advanced.StreamAsync(query);
+
+        while (await stream.MoveNextAsync())
+        {
+            // The result is just the ID string
+            var result = stream.Current.Document;
+            string? docId = null;
+
+            // Handle both direct ID strings and objects with Id property
+            if (result is string idString)
+            {
+                docId = idString;
+            }
+            else if (result != null)
+            {
+                // Try to get Id property dynamically
+                try
+                {
+                    docId = (result as dynamic)?.Id ?? stream.Current.Id;
+                }
+                catch
+                {
+                    docId = stream.Current.Id;
+                }
+            }
+
+            if (string.IsNullOrEmpty(docId) == false && TryExtractNumericId(docId, collection, out var numericId))
+            {
+                ids.Add(numericId);
+            }
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// Extracts numeric ID from document ID format: "questions/123" -> 123
+    /// </summary>
+    private static bool TryExtractNumericId(string docId, string expectedPrefix, out int numericId)
+    {
+        numericId = 0;
+
+        var prefix = expectedPrefix + "/";
+        if (!docId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var idPart = docId.Substring(prefix.Length);
+        return int.TryParse(idPart, out numericId);
+    }
+}


### PR DESCRIPTION
Extends Raven.Bench to support StackOverflow dataset benchmarks.

Introduces new workload profiles for StackOverflow, including random reads and parameterized queries.
Adds dataset management features for automatic download and import of StackOverflow data.
Supports dataset profiles (small, half, full) and custom dataset sizes.
Caches sampled document IDs to ensure the workload uses existent data.

Adds bulk writes profile.
