### PR TITLE
Add parameterized query workload with index usage tracking

### DIFF
--- a/src/RavenBench/Cli/CliParsing.cs
+++ b/src/RavenBench/Cli/CliParsing.cs
@@ -82,7 +82,7 @@ internal static class CliParsing
     private static WorkloadProfile ParseProfile(string profile)
     {
         if (string.IsNullOrWhiteSpace(profile))
-            throw new ArgumentException("--profile is required. Valid options: mixed, writes, reads, query-by-id");
+            throw new ArgumentException("--profile is required. Valid options: mixed, writes, reads, query-by-id, query-users-by-name");
 
         return profile.Trim().ToLowerInvariant() switch
         {
@@ -93,7 +93,8 @@ internal static class CliParsing
             "bulk-writes" or "bulkwrites" => WorkloadProfile.BulkWrites,
             "stackoverflow-reads" or "so-reads" => WorkloadProfile.StackOverflowReads,
             "stackoverflow-queries" or "so-queries" => WorkloadProfile.StackOverflowQueries,
-            _ => throw new ArgumentException($"Invalid profile: {profile}. Valid options: mixed, writes, reads, query-by-id, bulk-writes, stackoverflow-reads, stackoverflow-queries")
+            "query-users-by-name" or "queryusersbyname" => WorkloadProfile.QueryUsersByName,
+            _ => throw new ArgumentException($"Invalid profile: {profile}. Valid options: mixed, writes, reads, query-by-id, bulk-writes, stackoverflow-reads, stackoverflow-queries, query-users-by-name")
         };
     }
 

--- a/src/RavenBench/Cli/RunSettings.cs
+++ b/src/RavenBench/Cli/RunSettings.cs
@@ -27,7 +27,7 @@ public sealed class RunSettings : CommandSettings
     public string? Updates { get; init; }
 
     [CommandOption("--profile")]
-    [Description("Required. Operation profile: mixed, writes, reads, query-by-id, bulk-writes")]
+    [Description("Required. Operation profile: mixed, writes, reads, query-by-id, bulk-writes, stackoverflow-reads, stackoverflow-queries, query-users-by-name")]
     public string? Profile { get; init; }
 
     [CommandOption("--bulk-batch-size")]

--- a/src/RavenBench/Reporting/CsvMetrics.cs
+++ b/src/RavenBench/Reporting/CsvMetrics.cs
@@ -58,6 +58,16 @@ namespace RavenBench.Reporting
             new("SnmpIoWriteBytesPerSec", summary => summary.Options.SnmpEnabled, s => s.SnmpIoWriteBytesPerSec),
             new("ServerSnmpRequestsPerSec", summary => summary.Options.SnmpEnabled, s => s.ServerSnmpRequestsPerSec),
             new("SnmpErrorsPerSec", summary => summary.Options.SnmpEnabled && summary.Options.Snmp.Profile == SnmpProfile.Extended, s => s.SnmpErrorsPerSec),
+
+            // Query metadata - visible when any step has query metadata
+            new("QueryOperations", summary => summary.Steps.Any(s => s.QueryOperations.HasValue), s => s.QueryOperations),
+            new("MinResultCount", summary => summary.Steps.Any(s => s.MinResultCount.HasValue), s => s.MinResultCount),
+            new("MaxResultCount", summary => summary.Steps.Any(s => s.MaxResultCount.HasValue), s => s.MaxResultCount),
+            new("AvgResultCount", summary => summary.Steps.Any(s => s.AvgResultCount.HasValue), s => s.AvgResultCount),
+            new("TotalResults", summary => summary.Steps.Any(s => s.TotalResults.HasValue), s => s.TotalResults),
+            new("StaleQueryCount", summary => summary.Steps.Any(s => s.StaleQueryCount.HasValue), s => s.StaleQueryCount),
+            new("PrimaryIndex", summary => summary.Steps.Any(s => s.IndexUsage != null && s.IndexUsage.Count > 0), s => s.IndexUsage?.OrderByDescending(kvp => kvp.Value).FirstOrDefault().Key),
+            new("PrimaryIndexUsage", summary => summary.Steps.Any(s => s.IndexUsage != null && s.IndexUsage.Count > 0), s => s.IndexUsage?.OrderByDescending(kvp => kvp.Value).FirstOrDefault().Value),
         };
 
         public static List<CsvField> GetVisibleFields(BenchmarkSummary summary)

--- a/src/RavenBench/Reporting/Models.cs
+++ b/src/RavenBench/Reporting/Models.cs
@@ -124,4 +124,24 @@ public sealed class StepResult
     public double? SnmpErrorsPerSec { get; init; }
 
     public string? Reason { get; set; }
+
+    // Query metadata (populated for query workload profiles)
+    public long? QueryOperations { get; init; }
+    public IReadOnlyDictionary<string, long>? IndexUsage { get; init; }
+    public List<IndexUsageSummary>? TopIndexes { get; init; }
+    public int? MinResultCount { get; init; }
+    public int? MaxResultCount { get; init; }
+    public double? AvgResultCount { get; init; }
+    public long? TotalResults { get; init; }
+    public long? StaleQueryCount { get; init; }
+}
+
+/// <summary>
+/// Summarizes index usage for a single index (used in top-N summaries).
+/// </summary>
+public sealed class IndexUsageSummary
+{
+    public required string IndexName { get; init; }
+    public required long UsageCount { get; init; }
+    public double? UsagePercent { get; init; }
 }

--- a/src/RavenBench/Transport/ITransport.cs
+++ b/src/RavenBench/Transport/ITransport.cs
@@ -6,12 +6,31 @@ using RavenBench.Util;
 
 namespace RavenBench.Transport;
 
-public readonly struct TransportResult(long bytesOut, long bytesIn, string? errorDetails = null)
+/// <summary>
+/// Represents the result of a transport operation execution.
+/// Includes byte counts, error details, and optional query-specific metadata.
+/// </summary>
+public readonly struct TransportResult(long bytesOut, long bytesIn, string? errorDetails = null, string? indexName = null, int? resultCount = null, bool? isStale = null)
 {
     public long BytesOut { get; } = bytesOut;
     public long BytesIn { get; } = bytesIn;
     public string? ErrorDetails { get; } = errorDetails;
     public bool IsSuccess => ErrorDetails == null;
+
+    /// <summary>
+    /// Index name used by the query (populated for query operations).
+    /// </summary>
+    public string? IndexName { get; } = indexName;
+
+    /// <summary>
+    /// Number of results returned (populated for query operations).
+    /// </summary>
+    public int? ResultCount { get; } = resultCount;
+
+    /// <summary>
+    /// Whether the index was stale at query time (populated for query operations).
+    /// </summary>
+    public bool? IsStale { get; } = isStale;
 }
 
 public readonly struct CalibrationResult(double ttfbMs, double totalMs, long bytesDown, Version httpVersion, bool isSuccess = true, string? errorDetails = null)

--- a/src/RavenBench/Util/RunOptions.cs
+++ b/src/RavenBench/Util/RunOptions.cs
@@ -81,5 +81,6 @@ public enum WorkloadProfile
     QueryById,
     BulkWrites,
     StackOverflowReads,
-    StackOverflowQueries
+    StackOverflowQueries,
+    QueryUsersByName
 }

--- a/src/RavenBench/Workload/IWorkload.cs
+++ b/src/RavenBench/Workload/IWorkload.cs
@@ -16,9 +16,30 @@ public class ReadOperation : OperationBase
     public required string Id { get; init; }
 }
 
+/// <summary>
+/// Represents a parameterized RQL query operation.
+/// For legacy id-based queries, use QueryText="from @all_docs where id() = $id" with Parameters["id"] = docId.
+/// For equality queries, use QueryText="from Users where Name = $name" with Parameters["name"] = value.
+/// </summary>
 public class QueryOperation : OperationBase
 {
-    public required string Id { get; init; }
+    /// <summary>
+    /// The RQL query text with parameter placeholders (e.g., "from Users where Name = $name").
+    /// </summary>
+    public required string QueryText { get; init; }
+
+    /// <summary>
+    /// Query parameters to bind (e.g., { "name": "John" }).
+    /// </summary>
+    public required IReadOnlyDictionary<string, object?> Parameters { get; init; }
+
+    /// <summary>
+    /// Optional expected index name for validation/reporting.
+    /// </summary>
+    public string? ExpectedIndex { get; init; }
+
+    // Legacy compatibility: provide Id property that extracts from parameters for backward compatibility
+    public string? Id => Parameters.TryGetValue("id", out var idValue) ? idValue?.ToString() : null;
 }
 
 public class InsertOperation<T> : OperationBase

--- a/src/RavenBench/Workload/QueryWorkload.cs
+++ b/src/RavenBench/Workload/QueryWorkload.cs
@@ -17,7 +17,12 @@ public sealed class QueryWorkload : IWorkload
     public OperationBase NextOperation(Random rng)
     {
         var k = _distribution.NextKey(rng, (int)Math.Min(_maxKey, int.MaxValue));
-        return new QueryOperation { Id = IdFor(k) };
+        var docId = IdFor(k);
+        return new QueryOperation
+        {
+            QueryText = "from @all_docs where id() = $id",
+            Parameters = new Dictionary<string, object?> { ["id"] = docId }
+        };
     }
 
     private static string IdFor(long i) => $"bench/{i:D8}";

--- a/src/RavenBench/Workload/StackOverflowQueryWorkload.cs
+++ b/src/RavenBench/Workload/StackOverflowQueryWorkload.cs
@@ -25,6 +25,11 @@ public sealed class StackOverflowQueryWorkload : IWorkload
     public OperationBase NextOperation(Random rng)
     {
         var questionId = _questionIds[rng.Next(_questionIds.Length)];
-        return new QueryOperation { Id = $"questions/{questionId}" };
+        var docId = $"questions/{questionId}";
+        return new QueryOperation
+        {
+            QueryText = "from @all_docs where id() = $id",
+            Parameters = new Dictionary<string, object?> { ["id"] = docId }
+        };
     }
 }

--- a/src/RavenBench/Workload/UsersByNameQueryWorkload.cs
+++ b/src/RavenBench/Workload/UsersByNameQueryWorkload.cs
@@ -1,0 +1,189 @@
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+
+namespace RavenBench.Workload;
+
+/// <summary>
+/// Metadata for Users collection, containing sampled names for parameterized equality queries.
+/// </summary>
+public sealed class UsersWorkloadMetadata
+{
+    public string[] SampleNames { get; set; } = Array.Empty<string>();
+    public long SampleCount { get; set; }
+    public long TotalUserCount { get; set; }
+    public DateTime ComputedAt { get; set; }
+}
+
+/// <summary>
+/// Helper for discovering and caching Users workload metadata (sampled names).
+/// </summary>
+public static class UsersWorkloadHelper
+{
+    private const string MetadataDocId = "workload/users-metadata";
+    private const int DefaultSampleSize = 10000;
+
+    /// <summary>
+    /// Discovers actual user names by sampling the database and caches them for workload use.
+    /// Returns sampled names that exist in the database.
+    /// </summary>
+    public static async Task<UsersWorkloadMetadata> DiscoverOrLoadMetadataAsync(
+        string serverUrl,
+        string databaseName,
+        int sampleSize = DefaultSampleSize)
+    {
+        using var store = new DocumentStore
+        {
+            Urls = new[] { serverUrl },
+            Database = databaseName
+        };
+        store.Initialize();
+
+        // Check if we have cached metadata
+        using var session = store.OpenAsyncSession();
+        var cached = await session.LoadAsync<UsersWorkloadMetadata>(MetadataDocId);
+
+        if (cached != null && cached.SampleNames.Length > 0)
+        {
+            Console.WriteLine($"[Workload] Using cached Users metadata: {cached.SampleNames.Length} sampled names");
+            return cached;
+        }
+
+        Console.WriteLine("[Workload] Discovering Users names by sampling database...");
+
+        // Sample actual names from the database
+        var sampleNames = await SampleUserNamesAsync(store, sampleSize);
+
+        if (sampleNames.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Failed to discover Users names. Found {sampleNames.Count} names. " +
+                "Ensure the Users dataset is imported before running benchmarks.");
+        }
+
+        // Get actual total count of Users documents
+        var totalUserCount = await GetTotalUserCountAsync(store);
+
+        Console.WriteLine($"[Workload] Sampled {sampleNames.Count} unique user names from {totalUserCount} total users");
+
+        // Store metadata for future use
+        var metadata = new UsersWorkloadMetadata
+        {
+            SampleNames = sampleNames.ToArray(),
+            SampleCount = sampleNames.Count,
+            TotalUserCount = totalUserCount,
+            ComputedAt = DateTime.UtcNow
+        };
+
+        await session.StoreAsync(metadata, MetadataDocId);
+        await session.SaveChangesAsync();
+        Console.WriteLine("[Workload] Stored Users workload metadata in database");
+
+        return metadata;
+    }
+
+    /// <summary>
+    /// Samples user names from the Users collection using RavenDB's random() ordering.
+    /// Returns a list of actual names that exist in the database.
+    /// Uses a deterministic seed for reproducibility.
+    /// </summary>
+    private static async Task<HashSet<string>> SampleUserNamesAsync(
+        IDocumentStore store,
+        int sampleSize)
+    {
+        var names = new HashSet<string>();
+
+        using var session = store.OpenAsyncSession();
+
+        // Use RavenDB's built-in random() ordering with a fixed seed for deterministic sampling
+        var seed = "ravenbench-users-sampling-seed";
+        var query = session.Advanced.AsyncRawQuery<dynamic>($"from Users order by random('{seed}') select Name limit {sampleSize}");
+
+        await using var stream = await session.Advanced.StreamAsync(query);
+
+        while (await stream.MoveNextAsync())
+        {
+            // The result is the Name field
+            var result = stream.Current.Document;
+            string? name = null;
+
+            // Handle both direct string values and objects with Name property
+            if (result is string nameString)
+            {
+                name = nameString;
+            }
+            else if (result != null)
+            {
+                // Try to get Name property dynamically
+                try
+                {
+                    name = (result as dynamic)?.Name;
+                }
+                catch
+                {
+                    // Fallback: skip this entry
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(name) == false)
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Gets the total count of documents in the Users collection.
+    /// </summary>
+    private static async Task<long> GetTotalUserCountAsync(IDocumentStore store)
+    {
+        using var session = store.OpenAsyncSession();
+
+        // Use simple streaming count - efficient for any collection size
+        var count = 0L;
+        await using var stream = await session.Advanced.StreamAsync<object>(startsWith: "users/");
+        while (await stream.MoveNextAsync())
+        {
+            count++;
+        }
+
+        return count;
+    }
+}
+
+/// <summary>
+/// Workload that exercises parameterized equality queries against the Users collection.
+/// Queries use the pattern: FROM Users WHERE Name = $name
+/// </summary>
+public sealed class UsersByNameQueryWorkload : IWorkload
+{
+    private readonly string[] _sampleNames;
+    private const string ExpectedIndexName = "Auto/Users/ByName";
+
+    /// <summary>
+    /// Creates a Users query workload using sampled names.
+    /// </summary>
+    /// <param name="metadata">Workload metadata containing sampled user names</param>
+    public UsersByNameQueryWorkload(UsersWorkloadMetadata metadata)
+    {
+        if (metadata.SampleNames.Length == 0)
+        {
+            throw new ArgumentException("Metadata must contain sampled user names");
+        }
+
+        _sampleNames = metadata.SampleNames;
+    }
+
+    public OperationBase NextOperation(Random rng)
+    {
+        var name = _sampleNames[rng.Next(_sampleNames.Length)];
+
+        return new QueryOperation
+        {
+            QueryText = "from Users where Name = $name",
+            Parameters = new Dictionary<string, object?> { ["name"] = name },
+            ExpectedIndex = ExpectedIndexName
+        };
+    }
+}

--- a/tests/RavenBench.Tests/Cli/RunSettingsProfileTests.cs
+++ b/tests/RavenBench.Tests/Cli/RunSettingsProfileTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using RavenBench.Cli;
+using RavenBench.Util;
+using Xunit;
+
+namespace RavenBench.Tests.Cli;
+
+public class RunSettingsProfileTests
+{
+    [Fact]
+    public void ToRunOptions_AllowsQueryUsersByNameProfile()
+    {
+        // Arrange: configure the new equality workload profile that should be supported per PRD.
+        var settings = new RunSettings
+        {
+            Url = "http://localhost:8080",
+            Database = "bench",
+            Profile = "query-users-by-name"
+        };
+
+        // Act
+        var options = settings.ToRunOptions();
+
+        // Assert
+        options.Profile.Should().Be(WorkloadProfile.QueryUsersByName);
+    }
+}

--- a/tests/RavenBench.Tests/Workload/UsersByNameQueryWorkloadTests.cs
+++ b/tests/RavenBench.Tests/Workload/UsersByNameQueryWorkloadTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using RavenBench.Workload;
+using Xunit;
+
+namespace RavenBench.Tests.Workload;
+
+public class UsersByNameQueryWorkloadTests
+{
+    [Fact]
+    public void Rejects_Empty_Metadata()
+    {
+        var emptyMetadata = new UsersWorkloadMetadata
+        {
+            SampleNames = Array.Empty<string>(),
+            SampleCount = 0,
+            TotalUserCount = 0,
+            ComputedAt = DateTime.UtcNow
+        };
+
+        var act = () => new UsersByNameQueryWorkload(emptyMetadata);
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Metadata must contain sampled user names");
+    }
+
+    [Fact]
+    public void Generates_Query_Operations_With_Parameters()
+    {
+        var metadata = new UsersWorkloadMetadata
+        {
+            SampleNames = new[] { "Alice", "Bob", "Charlie" },
+            SampleCount = 3,
+            TotalUserCount = 1000,
+            ComputedAt = DateTime.UtcNow
+        };
+
+        var workload = new UsersByNameQueryWorkload(metadata);
+        var rng = new Random(42);
+        var op = workload.NextOperation(rng);
+
+        op.Should().BeOfType<QueryOperation>();
+        var queryOp = (QueryOperation)op;
+
+        queryOp.QueryText.Should().Be("from Users where Name = $name");
+        queryOp.Parameters.Should().ContainKey("name");
+        queryOp.Parameters["name"].Should().BeOneOf("Alice", "Bob", "Charlie");
+        queryOp.ExpectedIndex.Should().Be("Auto/Users/ByName");
+    }
+
+    [Fact]
+    public void Samples_All_Names_Uniformly()
+    {
+        var metadata = new UsersWorkloadMetadata
+        {
+            SampleNames = new[] { "Alice", "Bob", "Charlie" },
+            SampleCount = 3,
+            TotalUserCount = 1000,
+            ComputedAt = DateTime.UtcNow
+        };
+
+        var workload = new UsersByNameQueryWorkload(metadata);
+        var rng = new Random(42);
+        var namesSeen = new HashSet<string>();
+
+        // Generate enough operations to see all names
+        for (int i = 0; i < 100; i++)
+        {
+            var op = (QueryOperation)workload.NextOperation(rng);
+            namesSeen.Add(op.Parameters["name"]!.ToString()!);
+        }
+
+        // With 100 operations and 3 names, we should see all of them
+        namesSeen.Should().BeEquivalentTo("Alice", "Bob", "Charlie");
+    }
+
+    [Fact]
+    public void Metadata_Tracks_Sample_And_Total_Counts()
+    {
+        var metadata = new UsersWorkloadMetadata
+        {
+            SampleNames = new[] { "Alice", "Bob", "Charlie", "David", "Eve" },
+            SampleCount = 5,
+            TotalUserCount = 10000,
+            ComputedAt = DateTime.UtcNow
+        };
+
+        metadata.SampleCount.Should().Be(5);
+        metadata.TotalUserCount.Should().Be(10000);
+        metadata.SampleNames.Length.Should().Be((int)metadata.SampleCount);
+    }
+}


### PR DESCRIPTION
Add parameterized query workload with index usage tracking
Extends query support beyond document-by-ID to parameterized RQL queries
with proper index usage metrics. Adds Users-by-name equality query workload
that discovers and samples real user names from the database.
- Refactor QueryOperation to support parameterized RQL with named parameters
- Add query metadata capture (index name, result count, staleness) in transport layer
- Implement UsersByNameQueryWorkload with automatic name discovery and caching
- Add query-specific metrics: index usage, result counts, stale query tracking
- Extend CSV/JSON output with conditional query metric columns
- Update both RawHttpTransport and RavenClientTransport to extract query metadata
- Add query-users-by-name profile to CLI with proper validation
Query metadata is captured per-step and aggregated across benchmark runs.
Top 5 indexes by usage are summarized in results. Metrics only appear in
output when query workloads are active.
