### PR TITLE
transport: raw HTTP compresses request bodies with zstd

### DIFF
--- a/src/RavenBench.Core/RavenBench.Core.csproj
+++ b/src/RavenBench.Core/RavenBench.Core.csproj
@@ -8,6 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="RavenBench.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="HdrHistogram" Version="2.5.0" />
         <PackageReference Include="Lextm.SharpSnmpLib" Version="10.0.0" />
         <PackageReference Include="RavenDB.Client" Version="7.1.*" />

--- a/src/RavenBench.Core/Transport/RawHttpTransport.cs
+++ b/src/RavenBench.Core/Transport/RawHttpTransport.cs
@@ -18,6 +18,10 @@ public sealed class RawHttpTransport : ITransport
     private const int BufferSize = 32 * 1024;
     private const int PoolCount = 1024;
 
+    // ZstdSharp's Compressor is not thread-safe; one per worker thread, reused across requests.
+    // Default zstd level — add a level knob here if a run ever needs to vary it.
+    private static readonly ThreadLocal<Compressor> ZstdCompressor = new(() => new Compressor());
+
     private readonly HttpClient _http;
     private readonly string _baseUrl;
     private readonly string _db;
@@ -79,6 +83,30 @@ public sealed class RawHttpTransport : ITransport
             if (string.Equals(e, "zstd", StringComparison.OrdinalIgnoreCase)) return true;
         }
         return false;
+    }
+
+    // UTF-8 JSON request body, zstd-encoded when the run uses zstd (Content-Encoding: zstd).
+    // Content-Length is the compressed size, so wire-byte accounting reports it as-is.
+    private HttpContent CreateJsonContent(string json)
+        => _compression == CompressionMode.Zstd
+            ? ZstdJsonContent(Encoding.UTF8.GetBytes(json))
+            : new StringContent(json, Encoding.UTF8, "application/json");
+
+    private HttpContent CreateJsonContent(ReadOnlyMemory<byte> utf8Json)
+    {
+        if (_compression == CompressionMode.Zstd)
+            return ZstdJsonContent(utf8Json.Span);
+        var content = new ReadOnlyMemoryContent(utf8Json);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
+        return content;
+    }
+
+    internal static HttpContent ZstdJsonContent(ReadOnlySpan<byte> utf8Json)
+    {
+        var content = new ByteArrayContent(ZstdCompressor.Value!.Wrap(utf8Json).ToArray());
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
+        content.Headers.ContentEncoding.Add("zstd");
+        return content;
     }
 
     public async Task<TransportResult> ExecuteAsync(OperationBase op, CancellationToken ct)
@@ -236,7 +264,7 @@ public sealed class RawHttpTransport : ITransport
             };
 
             var queryPayload = JsonSerializer.Serialize(payload);
-            req.Content = new StringContent(queryPayload, Encoding.UTF8, "application/json");
+            req.Content = CreateJsonContent(queryPayload);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(30));
@@ -318,7 +346,7 @@ public sealed class RawHttpTransport : ITransport
             };
 
             var queryPayload = JsonSerializer.Serialize(payload);
-            req.Content = new StringContent(queryPayload, Encoding.UTF8, "application/json");
+            req.Content = CreateJsonContent(queryPayload);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(30));
@@ -365,7 +393,7 @@ public sealed class RawHttpTransport : ITransport
 
             var payload = new { Patch = new { Script = patchOp.Script, Values = new { } } };
             var jsonPayload = JsonSerializer.Serialize(payload);
-            req.Content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+            req.Content = CreateJsonContent(jsonPayload);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(30));
@@ -482,8 +510,7 @@ public sealed class RawHttpTransport : ITransport
                 writer.WriteEndObject();
             }
             int jsonByteCount = bufferWriter.WrittenCount;
-            req.Content = new ReadOnlyMemoryContent(bufferWriter.WrittenMemory);
-            req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
+            req.Content = CreateJsonContent(bufferWriter.WrittenMemory);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(30));
@@ -573,7 +600,7 @@ public sealed class RawHttpTransport : ITransport
             req.Headers.ExpectContinue = false;
 
             string jsonPayload = document is string s ? s : JsonSerializer.Serialize(document);
-            req.Content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+            req.Content = CreateJsonContent(jsonPayload);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(30));
@@ -773,8 +800,7 @@ public sealed class RawHttpTransport : ITransport
             }
             var jsonBytes = bufferWriter.WrittenMemory;
             var jsonByteCount = jsonBytes.Length;
-            req.Content = new ReadOnlyMemoryContent(jsonBytes);
-            req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
+            req.Content = CreateJsonContent(jsonBytes);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(30));

--- a/src/RavenBench.Core/Transport/RawHttpTransport.cs
+++ b/src/RavenBench.Core/Transport/RawHttpTransport.cs
@@ -109,6 +109,18 @@ public sealed class RawHttpTransport : ITransport
         return content;
     }
 
+    // Parses a JSON response, decoding zstd first. HttpClient does not auto-decode zstd, so any
+    // response path that parses the body must route through here. wireMs holds the raw wire bytes
+    // (already counted for bytesIn); identity passes straight through.
+    private static async Task<JsonDocument> ParseJsonResponseAsync(MemoryStream wireMs, HttpResponseMessage resp, CancellationToken ct)
+    {
+        if (NeedsZstdDecode(resp) == false)
+            return await JsonDocument.ParseAsync(wireMs, cancellationToken: ct).ConfigureAwait(false);
+
+        await using var zstdStream = new DecompressionStream(wireMs);
+        return await JsonDocument.ParseAsync(zstdStream, cancellationToken: ct).ConfigureAwait(false);
+    }
+
     public async Task<TransportResult> ExecuteAsync(OperationBase op, CancellationToken ct)
     {
         try
@@ -278,10 +290,10 @@ public sealed class RawHttpTransport : ITransport
                     return new TransportResult(0, 0, errorDetails);
                 }
 
-                using var ms = await BufferResponseAsync(resp, ct).ConfigureAwait(false);
-                long bytesIn = ms.Length;
+                using var wireMs = await BufferResponseAsync(resp, ct).ConfigureAwait(false);
+                long bytesIn = wireMs.Length;
 
-                using var doc = await JsonDocument.ParseAsync(ms, cancellationToken: ct).ConfigureAwait(false);
+                using var doc = await ParseJsonResponseAsync(wireMs, resp, ct).ConfigureAwait(false);
 
                 var indexName = doc.RootElement.TryGetProperty("IndexName", out var indexProp)
                     ? indexProp.GetString()
@@ -818,17 +830,7 @@ public sealed class RawHttpTransport : ITransport
                 using var wireMs = await BufferResponseAsync(resp, ct).ConfigureAwait(false);
                 long bytesIn = wireMs.Length;
 
-                // Zstd is not auto-decompressed by HttpClient; decode before parsing JSON.
-                Stream parseStream = wireMs;
-                Stream? zstdStream = null;
-                if (NeedsZstdDecode(resp))
-                {
-                    zstdStream = new DecompressionStream(wireMs);
-                    parseStream = zstdStream;
-                }
-
-                using var doc = await JsonDocument.ParseAsync(parseStream, cancellationToken: ct).ConfigureAwait(false);
-                zstdStream?.Dispose();
+                using var doc = await ParseJsonResponseAsync(wireMs, resp, ct).ConfigureAwait(false);
 
                 var indexName = doc.RootElement.TryGetProperty("IndexName", out var indexProp)
                     ? indexProp.GetString()

--- a/tests/RavenBench.Tests/RawHttpTransportTests.cs
+++ b/tests/RavenBench.Tests/RawHttpTransportTests.cs
@@ -44,6 +44,19 @@ public class RawHttpTransportTests
     }
 
     [Fact]
+    public async Task Zstd_Request_Body_Is_Encoded_And_Decodes_To_Original()
+    {
+        var json = "{\"field0\":\"hello zstd compression\",\"field1\":\"abcabcabcabcabcabc\"}";
+
+        using var content = RawHttpTransport.ZstdJsonContent(System.Text.Encoding.UTF8.GetBytes(json));
+
+        content.Headers.ContentEncoding.Should().Contain("zstd");
+        var wire = await content.ReadAsByteArrayAsync();
+        using var decompressor = new ZstdSharp.Decompressor();
+        System.Text.Encoding.UTF8.GetString(decompressor.Unwrap(wire).ToArray()).Should().Be(json);
+    }
+
+    [Fact]
     public void CancelledResult_Is_Not_An_Error_And_Is_Flagged_Cancelled()
     {
         var result = TransportResult.CancelledResult;


### PR DESCRIPTION
## What

`RawHttpTransport` already set `Accept-Encoding: zstd` and decoded zstd **responses**, but every **request** body went up uncompressed. With `--compression zstd` the raw transport now zstd-encodes outgoing JSON (PUT / PATCH / query / stream-query / bulk / vector) and sets `Content-Encoding: zstd`, so the raw transport is symmetric and wire-accurate in both directions. Attachment bodies stay raw (binary, matching the client).

## How

- `CreateJsonContent` helper wraps each JSON body, zstd-encoding it only when the run uses zstd; identity keeps `StringContent`/`ReadOnlyMemoryContent` unchanged.
- Per-thread `Compressor` (ZstdSharp is not thread-safe).
- Byte accounting already reads `Content-Length`, so the compressed size is reported as-is — no accounting change.

## Test

New `Zstd_Request_Body_Is_Encoded_And_Decodes_To_Original`: asserts the produced body carries `Content-Encoding: zstd` and decodes back to the exact JSON. Full `RawHttpTransportTests` (13) pass; project builds clean.

End-to-end validation against a live RavenDB 7.2 server is the upcoming zstd benchmark arm.