### PR TITLE
Clamp warmup latency to histogram ceiling instead of crashing

### DIFF
--- a/src/RavenBench.Core/ClosedLoopLoadGenerator.cs
+++ b/src/RavenBench.Core/ClosedLoopLoadGenerator.cs
@@ -84,7 +84,7 @@ namespace RavenBench.Core
 
                         counters.Record(result);
                         if (warmupRecorder != null && result.IsError == false)
-                            warmupRecorder.RecordValue(result.LatencyMicros);
+                            warmupRecorder.RecordValue(Math.Min(result.LatencyMicros, LatencyRecorder.MaxTrackableMicros));
                     }
                 }, cancellationToken);
             }

--- a/src/RavenBench.Core/Metrics/LatencyRecorder.cs
+++ b/src/RavenBench.Core/Metrics/LatencyRecorder.cs
@@ -20,6 +20,8 @@ namespace RavenBench.Core.Metrics;
 /// </remarks>
 public sealed class LatencyRecorder : IDisposable
 {
+    public const long MaxTrackableMicros = 60_000_000;
+
     private readonly bool _enabled;
     private readonly Recorder _recorder;
     private long _maxMicros;
@@ -44,7 +46,7 @@ public sealed class LatencyRecorder : IDisposable
             // If a latency exceeds 60s, the histogram will throw an exception (fail-fast).
             _recorder = new Recorder(
                 lowestDiscernibleValue: 1,
-                highestTrackableValue: 60_000_000,  // 60 seconds in microseconds
+                highestTrackableValue: MaxTrackableMicros,  // 60 seconds in microseconds
                 numberOfSignificantValueDigits: 3,
                 histogramFactory: (instanceId, low, high, digits) => new LongHistogram(low, high, digits));
 


### PR DESCRIPTION
## Problem

`ClosedLoopLoadGenerator` crashes with `System.IndexOutOfRangeException` and aborts the entire run when a single **successful** operation takes longer than 60 s.

The warmup floor recorder records straight into a raw HdrHistogram with no overflow handling:

```csharp
warmupRecorder.RecordValue(result.LatencyMicros);   // throws if > 60s
```

The measurement path is hardened — `LatencyRecorder.Record` catches the overflow and `ExecuteOperationAsync` converts it to a benign error (the intended knee signal). But during warmup `latencyRecorder` is disabled, so the *only* active histogram is `warmupRecorder`, and that one call is unprotected. Its 60 s ceiling was inherited from `LatencyRecorder` but its safety net was not.

This only trips on a saturated single-core box (e.g. Azure B1ms), where a request can succeed after >60 s. Larger boxes never feed a >60 s value, so they never hit it.

## Fix

Clamp the warmup sample to the histogram ceiling — a >60 s latency is unusable for a baseline floor anyway:

```csharp
warmupRecorder.RecordValue(Math.Min(result.LatencyMicros, LatencyRecorder.MaxTrackableMicros));
```

The 60 s ceiling is hoisted into a single `LatencyRecorder.MaxTrackableMicros` constant, used by both `LatencyRecorder`'s own `Recorder` config and the clamp.

Measurement path is unchanged — there an overflow→error is the intended early-termination signal.
